### PR TITLE
PT-3550: Updated ontologizer-core to use slf4j

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,6 +17,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.22</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.att.research</groupId>
       <artifactId>grappa</artifactId>
       <version>1.2.1</version>

--- a/core/src/main/java/ontologizer/FileCache.java
+++ b/core/src/main/java/ontologizer/FileCache.java
@@ -21,8 +21,8 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Thread-class for downloading.
@@ -31,7 +31,7 @@ import java.util.logging.Logger;
  */
 class DownloadThread extends Thread
 {
-    private static Logger logger = Logger.getLogger(DownloadThread.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(DownloadThread.class.getName());
 
     private List<FileCache.FileDownload> callbackSubscriberList = new LinkedList<FileCache.FileDownload>();
 
@@ -136,7 +136,7 @@ class DownloadThread extends Thread
 
         InputStream stream;
         try {
-            logger.fine("Open connection");
+            logger.debug("Open connection");
 
             if (this.proxy != null) {
                 this.urlConnection = this.u.openConnection(this.proxy);
@@ -148,7 +148,7 @@ class DownloadThread extends Thread
 
             int cl = this.urlConnection.getContentLength();
 
-            logger.fine("Content-Length = " + cl);
+            logger.debug("Content-Length = " + cl);
             synchronized (this) {
                 this.contentLength = cl;
             }
@@ -172,7 +172,7 @@ class DownloadThread extends Thread
             /* Forward ready status */
             this.downloadCallback.ready(null, this.destFile.getCanonicalPath());
         } catch (Exception e) {
-            logger.log(Level.SEVERE, "Exception while downloading a file.", e);
+            logger.error("Exception while downloading a file.", e);
             /* Forward ready status */
             this.downloadCallback.ready(e, null);
         }
@@ -202,7 +202,7 @@ class CachedFile implements Serializable
 public class FileCache
 {
     /** For our logging */
-    private static Logger logger = Logger.getLogger(FileCache.class.getCanonicalName());
+    private static Logger logger = LoggerFactory.getLogger(FileCache.class.getCanonicalName());
 
     /** That's the thread group */
     protected static ThreadGroup downloadThreadGroup;
@@ -319,9 +319,9 @@ public class FileCache
                 }
             }
         } catch (FileNotFoundException e) {
-            logger.log(Level.WARNING, String.format("The cache file was not found in %s.", cachePath));
+            logger.warn(String.format("The cache file was not found in %s.", cachePath));
         } catch (IOException e) {
-            logger.log(Level.WARNING, "", e);
+            logger.warn("", e);
         }
     }
 
@@ -450,7 +450,7 @@ public class FileCache
             DownloadThread dt = downloadHashMap.get(url);
             if (dt != null) {
                 synchronized (dt) {
-                    logger.fine("Added another request for the download for URL \"" + url + "\"");
+                    logger.debug("Added another request for the download for URL \"" + url + "\"");
 
                     if (ready != null) {
                         dt.getCallbackSubscriberList().add(ready);
@@ -463,7 +463,7 @@ public class FileCache
             if (fileCache.containsKey(url)) {
                 String cachedFilename = fileCache.get(url).cachedFilename;
                 if (new File(cachedFilename).exists()) {
-                    logger.fine("URL \"" + url + "\" has already been cached.");
+                    logger.debug("URL \"" + url + "\" has already been cached.");
                     return cachedFilename;
                 }
                 fileCache.remove(url);
@@ -484,7 +484,7 @@ public class FileCache
             t++;
         } while (destFile.exists());
 
-        logger.fine("Starting new download thread for URL \"" + url + "\" (cached as \"" + destFile.getAbsolutePath()
+        logger.debug("Starting new download thread for URL \"" + url + "\" (cached as \"" + destFile.getAbsolutePath()
             + "\"");
 
         /* Leave the process of downloading to the separate thread */

--- a/core/src/main/java/ontologizer/association/AssociationParser.java
+++ b/core/src/main/java/ontologizer/association/AssociationParser.java
@@ -16,7 +16,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.zip.GZIPInputStream;
 
 import ontologizer.go.PrefixPool;
@@ -37,7 +38,7 @@ import ontologizer.types.ByteString;
 
 public class AssociationParser
 {
-    private static Logger logger = Logger.getLogger(AssociationParser.class.getCanonicalName());
+    private static Logger logger = LoggerFactory.getLogger(AssociationParser.class);
 
     enum Type
     {
@@ -221,7 +222,7 @@ public class AssociationParser
                         Association assoc = new Association(new ByteString(fields[0]), tid.toString());
                         this.associations.add(assoc);
                     } else {
-                        logger.warning(tid.toString() + " which annotates " + fields[0] + " not found");
+                        logger.warn(tid.toString() + " which annotates " + fields[0] + " not found");
                     }
                 }
             }
@@ -435,7 +436,7 @@ public class AssociationParser
                             if (!dbObject.equals(assoc.getDB_Object())) {
                                 AssociationParser.this.symbolWarnings++;
                                 if (AssociationParser.this.symbolWarnings < 1000) {
-                                    logger.warning("Line " + this.lineno + ": Expected that symbol \""
+                                    logger.warn("Line " + this.lineno + ": Expected that symbol \""
                                         + assoc.getObjectSymbol() + "\" maps to \"" + dbObject + "\" but it maps to \""
                                         + assoc.getDB_Object() + "\"");
                                 }
@@ -450,7 +451,7 @@ public class AssociationParser
                             if (!objectSymbol.equals(assoc.getObjectSymbol())) {
                                 AssociationParser.this.dbObjectWarnings++;
                                 if (AssociationParser.this.dbObjectWarnings < 1000) {
-                                    logger.warning("Line " + this.lineno + ": Expected that dbObject \""
+                                    logger.warn("Line " + this.lineno + ": HRMM Expected that dbObject \""
                                         + assoc.getDB_Object() + "\" maps to symbol \"" + objectSymbol
                                         + "\" but it maps to \"" + assoc.getObjectSymbol() + "\"");
                                 }
@@ -509,10 +510,10 @@ public class AssociationParser
             + " items.");
 
         if (this.symbolWarnings >= 1000) {
-            logger.warning("The symbols of a total of " + this.symbolWarnings + " entries mapped ambiguously");
+            logger.warn("The symbols of a total of " + this.symbolWarnings + " entries mapped ambiguously");
         }
         if (this.dbObjectWarnings >= 1000) {
-            logger.warning("The objects of a  total of " + this.dbObjectWarnings + " entries mapped ambiguously");
+            logger.warn("The objects of a  total of " + this.dbObjectWarnings + " entries mapped ambiguously");
         }
 
         /*
@@ -639,7 +640,7 @@ public class AssociationParser
             item = item.substring(x, y);
 
             if (!item.equals(annot[i])) {
-                logger.severe("Found column header \"" + item + "\" but expected \"" + annot[i] + "\"");
+                logger.error("Found column header \"" + item + "\" but expected \"" + annot[i] + "\"");
                 headerFailure = true;
                 break;
             }

--- a/core/src/main/java/ontologizer/calculation/EnrichedGOTermsResult.java
+++ b/core/src/main/java/ontologizer/calculation/EnrichedGOTermsResult.java
@@ -10,8 +10,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Locale;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ontologizer.GlobalPreferences;
 import ontologizer.association.AssociationContainer;
@@ -31,7 +31,7 @@ import ontologizer.util.Util;
  */
 public class EnrichedGOTermsResult extends AbstractGOTermsResult
 {
-    private static Logger logger = Logger.getLogger(EnrichedGOTermsResult.class.getCanonicalName());
+    private static Logger logger = LoggerFactory.getLogger(EnrichedGOTermsResult.class.getCanonicalName());
 
     private int populationGeneCount;
 
@@ -129,7 +129,7 @@ public class EnrichedGOTermsResult extends AbstractGOTermsResult
 
             logger.info("\"" + file.getCanonicalPath() + "\"" + " successfully written.");
         } catch (IOException e) {
-            logger.log(Level.SEVERE, "Exception occured when writing the table.", e);
+            logger.error("Exception occured when writing the table.", e);
         }
     }
 

--- a/core/src/main/java/ontologizer/calculation/SemanticCalculation.java
+++ b/core/src/main/java/ontologizer/calculation/SemanticCalculation.java
@@ -12,7 +12,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ontologizer.association.Association;
 import ontologizer.association.AssociationContainer;
@@ -370,7 +371,7 @@ class IntHashMapForDoubles
 
 public class SemanticCalculation
 {
-    private static Logger logger = Logger.getLogger(SemanticCalculation.class.getCanonicalName());
+    private static Logger logger = LoggerFactory.getLogger(SemanticCalculation.class.getCanonicalName());
 
     public static interface ISemanticCalculationProgress
     {

--- a/core/src/main/java/ontologizer/calculation/SemanticResult.java
+++ b/core/src/main/java/ontologizer/calculation/SemanticResult.java
@@ -3,7 +3,8 @@ package ontologizer.calculation;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ontologizer.association.AssociationContainer;
 import ontologizer.go.Ontology;
@@ -11,7 +12,7 @@ import ontologizer.types.ByteString;
 
 public class SemanticResult
 {
-    private static Logger logger = Logger.getLogger(EnrichedGOTermsResult.class.getCanonicalName());
+    private static Logger logger = LoggerFactory.getLogger(EnrichedGOTermsResult.class.getCanonicalName());
 
     public Ontology g;
 

--- a/core/src/main/java/ontologizer/calculation/b2g/Bayes2GOCalculation.java
+++ b/core/src/main/java/ontologizer/calculation/b2g/Bayes2GOCalculation.java
@@ -7,7 +7,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ontologizer.association.AssociationContainer;
 import ontologizer.calculation.EnrichedGOTermsResult;
@@ -32,7 +33,7 @@ import ontologizer.types.ByteString;
  */
 public class Bayes2GOCalculation implements ICalculation
 {
-    private static Logger logger = Logger.getLogger(Bayes2GOCalculation.class.getCanonicalName());
+    private static Logger logger = LoggerFactory.getLogger(Bayes2GOCalculation.class.getCanonicalName());
 
     private boolean WRITE_STATS_FILE = false;
 

--- a/core/src/main/java/ontologizer/dotwriter/GODOTWriter.java
+++ b/core/src/main/java/ontologizer/dotwriter/GODOTWriter.java
@@ -5,7 +5,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ontologizer.BuildInfo;
 import ontologizer.go.Ontology;
@@ -16,7 +17,7 @@ import sonumina.math.graph.AbstractGraph.DotAttributesProvider;
 
 public class GODOTWriter
 {
-    private static Logger logger = Logger.getLogger(GODOTWriter.class.getCanonicalName());
+    private static Logger logger = LoggerFactory.getLogger(GODOTWriter.class.getCanonicalName());
 
     /**
      * Writes out a basic dot file which can be used within graphviz. All terms of the terms parameter are included in
@@ -163,7 +164,7 @@ public class GODOTWriter
                 }
             });
         } catch (IOException e) {
-            logger.severe("Unable to create dot file: " + e.getLocalizedMessage());
+            logger.error("Unable to create dot file: " + e.getLocalizedMessage());
             e.printStackTrace();
         }
     }

--- a/core/src/main/java/ontologizer/enumeration/GOTermCounter.java
+++ b/core/src/main/java/ontologizer/enumeration/GOTermCounter.java
@@ -5,7 +5,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ontologizer.go.Namespace;
 import ontologizer.go.Ontology;
@@ -22,7 +23,7 @@ import ontologizer.go.TermID;
 
 public class GOTermCounter implements Iterable<TermID>
 {
-    private static Logger logger = Logger.getLogger(GOTermCounter.class.getCanonicalName());
+    private static Logger logger = LoggerFactory.getLogger(GOTermCounter.class.getCanonicalName());
 
     /**
      * Explicit and total annotations to a given term in the biological process namespace; key: a GO:id, value: an

--- a/core/src/main/java/ontologizer/go/OBOParser.java
+++ b/core/src/main/java/ontologizer/go/OBOParser.java
@@ -10,7 +10,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.zip.GZIPInputStream;
 
 import ontologizer.association.AbstractByteLineScanner;
@@ -38,7 +39,7 @@ import sonumina.math.graph.Edge;
  */
 public class OBOParser
 {
-    private static Logger logger = Logger.getLogger(OBOParser.class.getCanonicalName());
+    private static Logger logger = LoggerFactory.getLogger(OBOParser.class.getCanonicalName());
 
     private enum Stanza
     {
@@ -208,7 +209,7 @@ public class OBOParser
             }
 
             if (this.currentID == null || this.currentName == null) {
-                logger.warning("Error parsing stanza: " + this.currentStanza.toString() + " currentID: "
+                logger.warn("Error parsing stanza: " + this.currentStanza.toString() + " currentID: "
                     + this.currentID
                     + ", currentName: " + this.currentName);
 

--- a/core/src/main/java/ontologizer/go/Ontology.java
+++ b/core/src/main/java/ontologizer/go/Ontology.java
@@ -9,7 +9,8 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import sonumina.math.graph.AbstractGraph.INeighbourGrabber;
 import sonumina.math.graph.AbstractGraph.IVisitor;
@@ -53,7 +54,7 @@ class OntologyEdge extends Edge<Term>
  */
 public class Ontology implements Iterable<Term>
 {
-    private static Logger logger = Logger.getLogger(Ontology.class.getCanonicalName());
+    private static Logger logger = LoggerFactory.getLogger(Ontology.class.getCanonicalName());
 
     /** This is used to identify Gene Ontology until a better way is found */
     private static HashSet<String> goLevel1TermNames = new HashSet<String>(Arrays.asList("molecular_function",

--- a/core/src/main/java/ontologizer/set/StudySet.java
+++ b/core/src/main/java/ontologizer/set/StudySet.java
@@ -12,7 +12,8 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ontologizer.association.Association;
 import ontologizer.association.AssociationContainer;
@@ -38,7 +39,7 @@ import ontologizer.types.ByteString;
  */
 public class StudySet implements Iterable<ByteString>
 {
-    private static Logger logger = Logger.getLogger(StudySet.class.getCanonicalName());
+    private static Logger logger = LoggerFactory.getLogger(StudySet.class.getCanonicalName());
 
     /**
      * HashMap containing the names of genes (or gene products) of the study and their optional description.
@@ -116,7 +117,7 @@ public class StudySet implements Iterable<ByteString>
     /*
      * public StudySet(String name, String [] entries) { this.name = name; try { if (entries != null) { OneOnALineParser
      * parser = new OneOnALineParser(entries); parseAndRetrieveGenesAndAttributes(parser); } } catch (IOException ex) {
-     * logger.warning(ex.getLocalizedMessage()); } }
+     * logger.warn(ex.getLocalizedMessage()); } }
      */
 
     /**

--- a/core/src/main/java/ontologizer/set/StudySetFactory.java
+++ b/core/src/main/java/ontologizer/set/StudySetFactory.java
@@ -2,7 +2,8 @@ package ontologizer.set;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -19,7 +20,7 @@ import ontologizer.types.ByteString;
  */
 public class StudySetFactory
 {
-    private static Logger logger = Logger.getLogger(StudySetFactory.class.getCanonicalName());
+    private static Logger logger = LoggerFactory.getLogger(StudySetFactory.class.getCanonicalName());
 
     private StudySetFactory()
     {

--- a/core/src/main/java/ontologizer/worksets/WorkSetLoadThread.java
+++ b/core/src/main/java/ontologizer/worksets/WorkSetLoadThread.java
@@ -9,8 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ontologizer.FileCache;
 import ontologizer.FileCache.FileCacheUpdateCallback;
@@ -32,7 +32,7 @@ import ontologizer.util.MemoryWarningSystem;
  */
 public class WorkSetLoadThread extends Thread
 {
-    private static Logger logger = Logger.getLogger(WorkSetLoadThread.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(WorkSetLoadThread.class.getName());
 
     private static class Message
     {
@@ -250,7 +250,7 @@ public class WorkSetLoadThread extends Thread
             @Override
             public void memoryUsageLow(long usedMemory, long maxMemory)
             {
-                logger.warning("Low memory condition! Trying to clean some caches");
+                logger.warn("Low memory condition! Trying to clean some caches");
                 cleanCache();
             }
         });
@@ -520,7 +520,7 @@ public class WorkSetLoadThread extends Thread
                 workSetProgress.initGauge(0);
             }
         } catch (Exception e) {
-            logger.log(Level.SEVERE, "Failed to load files", e);
+            logger.error("Failed to load files", e);
         }
     }
 

--- a/core/src/main/java/sonumina/math/graph/DirectedGraphDotLayout.java
+++ b/core/src/main/java/sonumina/math/graph/DirectedGraphDotLayout.java
@@ -6,8 +6,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import att.grappa.Element;
 import att.grappa.GraphEnumeration;
@@ -26,7 +26,7 @@ import sonumina.math.graph.AbstractGraph.DotAttributesProvider;
  */
 public class DirectedGraphDotLayout<T> extends DirectedGraphLayout<T>
 {
-    private static Logger logger = Logger.getLogger(DirectedGraphDotLayout.class.getCanonicalName());
+    private static Logger logger = LoggerFactory.getLogger(DirectedGraphDotLayout.class.getCanonicalName());
 
     /**
      * Dimensions of dot are specified using inches, this is the used dots per inch conversion number.
@@ -152,14 +152,14 @@ public class DirectedGraphDotLayout<T> extends DirectedGraphLayout<T>
                 emitPosition(g, (int) bb.getMinY());
                 rc = true;
             } else {
-                logger.severe(errStr.toString());
+                logger.error(errStr.toString());
             }
         } catch (IOException e) {
-            logger.log(Level.WARNING, "Unable to layout the graph", e);
+            logger.warn("Unable to layout the graph", e);
         } catch (InterruptedException e) {
-            logger.log(Level.WARNING, "Unable to layout the graph", e);
+            logger.warn("Unable to layout the graph", e);
         } catch (Exception e) {
-            logger.log(Level.WARNING, "Unable to layout the graph", e);
+            logger.warn("Unable to layout the graph", e);
         }
 
         return rc;


### PR DESCRIPTION
This allows xwikis logback config to filter these logs
Modules not used by phenotips were not updated and may still use java utils logging